### PR TITLE
Fixed the copy function

### DIFF
--- a/src/js/content-scripts/features/copy-code.js
+++ b/src/js/content-scripts/features/copy-code.js
@@ -24,23 +24,9 @@ function addCopyButton(block) {
 	const code = block.querySelector('code');
 
 	button.addEventListener('click', () => {
-		const plainText = getPlainText(code.innerHTML);
+		const plainText = code.innerText;
 		copyToClipboard(plainText);
 	});
-}
-
-function getPlainText(html) {
-	//stackoverflow.com//questions/15180173/convert-html-to-plain-text-in-js-without-browser-environment#answer-20071776
-	html = html.replace(/<style([\s\S]*?)<\/style>/gi, '');
-	html = html.replace(/<script([\s\S]*?)<\/script>/gi, '');
-	html = html.replace(/<\/div>/gi, '\n');
-	html = html.replace(/<\/li>/gi, '\n');
-	html = html.replace(/<li>/gi, '  *  ');
-	html = html.replace(/<\/ul>/gi, '\n');
-	html = html.replace(/<\/p>/gi, '\n');
-	html = html.replace(/<br\s*[\/]?>/gi, '\n');
-	html = html.replace(/<[^>]+>/gi, '');
-	return html;
 }
 
 function removeCopyButtons() {


### PR DESCRIPTION
Good night @riccardoFasan ! I fixed the copy button. 

Using ```innerHTML``` causes everything from StackOverFlow [hljs](https://highlightjs.org/) code block to be copied.
Using ```innerText```solved the problem.

Before (with innerHTML and the unnecessary function):
![before](https://user-images.githubusercontent.com/52143624/200080490-8c434960-2b85-4d86-a9e8-fa2b4a141b7d.png)
After (with just ```innerText```):
![after](https://user-images.githubusercontent.com/52143624/200080493-1043928b-7b32-4576-bc4a-5fb2b1bf3a99.png)
