### PR TITLE
Make README.md not direct to italian specific pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Now you can hide the navigation and tooltip bars, so that nothing can distract y
 
 ## Installation
 
-You can find the extension on the [Chrome Web Store](https://chrome.google.com/webstore/detail/stackoverflow-tweaks-tool/dfignoicphdepgloiodeaiokaepjbnan&authuser=0) and on the [Firefox add-ons](https://addons.mozilla.org/firefox/addon/stackoverflow-tweaks-tool/) page.
+You can find the extension on the [Chrome Web Store](https://chrome.google.com/webstore/detail/stackoverflow-tweaks-tool/dfignoicphdepgloiodeaiokaepjbnan) and on the [Firefox add-ons](https://addons.mozilla.org/firefox/addon/stackoverflow-tweaks-tool/) page.
 
 ### Building & manual installation
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Now you can hide the navigation and tooltip bars, so that nothing can distract y
 
 ## Installation
 
-You can find the extension on the [Chrome Web Store](https://chrome.google.com/webstore/detail/stackoverflow-tweaks-tool/dfignoicphdepgloiodeaiokaepjbnan?hl=it&authuser=0) and on the [Firefox add-ons](https://addons.mozilla.org/it/firefox/addon/stackoverflow-tweaks-tool/) page.
+You can find the extension on the [Chrome Web Store](https://chrome.google.com/webstore/detail/stackoverflow-tweaks-tool/dfignoicphdepgloiodeaiokaepjbnan&authuser=0) and on the [Firefox add-ons](https://addons.mozilla.org/firefox/addon/stackoverflow-tweaks-tool/) page.
 
 ### Building & manual installation
 


### PR DESCRIPTION
Current Behavior: When clicking on the firefox/chrome add-ons store, it directs you to the Italian-specific page.

This is undesirable and simply not specifying the language would be much preferable as people who don't speak/read Italian also wish to install the extension. This PR removes that specifying of the language to Italian.