### PR TITLE
Fix: chrome.storage.get return objects instead of values 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stack-overflow-tweaks-tool",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stack-overflow-tweaks-tool",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^10.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack-overflow-tweaks-tool",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "A tool to tweak the StackOverflow UI and boost your productivity.",
   "main": "manifest.json",
   "directories": {

--- a/src/js/content-scripts/init.js
+++ b/src/js/content-scripts/init.js
@@ -9,8 +9,8 @@ const features = [
 ];
 
 features.forEach(async (feature) => {
-  const property = await chrome.storage.sync.get(feature.name);
-  const value = property[feature.name];
+  const initialValueObject = await chrome.storage.sync.get(feature.name);
+  const value = initialValueObject[feature.name];
   if (value) feature.enable();
 });
 

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -22,17 +22,19 @@ function appendInput(feature) {
 
 features.forEach(async (feature) => {
   appendInput(feature);
-  let defaultValue = await chrome.storage.sync.get(feature.name);
-  if (defaultValue === undefined) {
-    defaultValue = false;
-    await chrome.storage.sync.set(feature.name, defaultValue);
+  const initialValueObject = await chrome.storage.sync.get(feature.name);
+  const initialValue = initialValueObject[feature.name];
+  if (initialValue === undefined) {
+    initialValue = false;
+    await chrome.storage.sync.set({ [feature.name]: initialValue });
   }
 
   const input = document.querySelector(`#${feature.name}`);
-  input.checked = defaultValue;
+  input.checked = initialValue;
 
   input.addEventListener('click', async () => {
-    const currentValue = await chrome.storage.sync.get(feature.name);
-    await chrome.storage.sync.set(feature.name, !currentValue);
+    const currentValueObject = await chrome.storage.sync.get(feature.name);
+    const currentValue = currentValueObject[feature.name];
+    await chrome.storage.sync.set({ [feature.name]: !currentValue });
   });
 });


### PR DESCRIPTION
In the last update (1.5.3) I refactored the codebase by removing some useless utilities and introducing the async/await syntax to improve the readability. But in doing this I forgot that chrome.storage.get returns an object instead of a boolean and this broke the whole extension. This PR fixes the bug.

I don't understand why I didn't notice the problem when I worked on refactoring. I think we could migrate to TypeScript to prevent new errors related to typings and increase stability.

Happy Holidays 🎅