### PR TITLE
Fix correct answer highlighting when using system theme

### DIFF
--- a/src/js/content-scripts/dom.js
+++ b/src/js/content-scripts/dom.js
@@ -27,14 +27,18 @@ const container = body.querySelector('#content');
 const content = container.querySelector('#mainbar');
 
 function isDarkTheme() {
-  return body.classList.contains('theme-dark') || body.classList.contains('theme-system') && window.matchMedia("(prefers-color-scheme: dark)").matches;
+  return (
+    body.classList.contains('theme-dark') ||
+    (body.classList.contains('theme-system') &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches)
+  );
 }
 
-window.matchMedia('(prefers-color-scheme: dark)')
+window
+  .matchMedia('(prefers-color-scheme: dark)')
   .addEventListener('change', () => {
     setGreen();
-  })
-
+  });
 
 function setGreen() {
   const green = isDarkTheme() ? darkGreen : lightGreen;

--- a/src/js/content-scripts/dom.js
+++ b/src/js/content-scripts/dom.js
@@ -26,10 +26,18 @@ const tooltipsBar = body.querySelector('#sidebar');
 const container = body.querySelector('#content');
 const content = container.querySelector('#mainbar');
 
-const isDarkTheme = body.classList.contains('theme-dark');
+function isDarkTheme() {
+  return body.classList.contains('theme-dark') || body.classList.contains('theme-system') && window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+window.matchMedia('(prefers-color-scheme: dark)')
+  .addEventListener('change', () => {
+    setGreen();
+  })
+
 
 function setGreen() {
-  const green = isDarkTheme ? darkGreen : lightGreen;
+  const green = isDarkTheme() ? darkGreen : lightGreen;
   setStyleVariable('injected-green', green);
 }
 


### PR DESCRIPTION
This change fixes the correct answer highlighting when using  'System theme' option in Stack Overflow. Previously the `isDarkTheme` boolean would be wrong due to the lack of `theme-dark` class, so this now checks the preferred colour scheme if not explicitly set by using `window.matchMedia("(prefers-color-scheme: dark)")`.

I have also added an event listener which trigger this update if the system theme changes.