### PR TITLE
Fix the colour of the copy code icon

### DIFF
--- a/src/js/content-scripts/features/copy-code.js
+++ b/src/js/content-scripts/features/copy-code.js
@@ -7,7 +7,7 @@ function addCopyButtons() {
   });
 }
 
-const copyClasses = isDarkTheme ? 'copy-button dark' : 'copy-button';
+const copyClasses = isDarkTheme() ? 'copy-button dark' : 'copy-button';
 
 function addCopyButton(block) {
   const button = document.createElement('button');


### PR DESCRIPTION
Correct the function call to `isDarkTheme` which was missing brackets which caussed the copy code icon to be the wrong colour.